### PR TITLE
Added PHP extension `bcmath` requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
 		}
 	],
 	"require": {
-		"php": ">=5.3"
+		"php": ">=5.3",
+		"ext-bcmath" : "*"
 	},
 	"autoload": {
 		"classmap": [


### PR DESCRIPTION
`ip2location/ip2proxy-php/class.IP2Proxy.php:818`
Used **bcadd** function from php bcmath extention

It makes the error:
>  Call to undefined function IP2Proxy\bcadd()

[read about php bcadd function](http://php.net/manual/ru/function.bcadd.php)

![image](https://user-images.githubusercontent.com/26322780/50223017-b2bfa480-03a2-11e9-9203-ff4ff110771e.png)
https://github.com/dev-sl/ip2proxy-php/blob/master/class.IP2Proxy.php#L829