### PR TITLE
Removing ext-gmp dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
 		"php": ">=7.2",
 		"ext-bcmath": "*",
 		"ext-curl": "*",
-		"ext-gmp": "*",
 		"ext-json": "*"
 	},
 	"autoload": {


### PR DESCRIPTION
Removes the `ext-gmp` dependency as project doesn't appear to actually use GMP.