### PR TITLE
Fix deprecation for PHP 8+

### DIFF
--- a/src/Database.php
+++ b/src/Database.php
@@ -581,7 +581,9 @@ class Database
 						shmop_write($shmId, $buf, $pointer);
 						$pointer += self::SHM_CHUNK_SIZE;
 					}
-					shmop_close($shmId);
+					if (PHP_MAJOR_VERSION < 8) {
+						shmop_close($shmId);
+					}
 					fclose($fp);
 
 					// now open the memory segment for readonly access


### PR DESCRIPTION
shmop_close function has been DEPRECATED as of PHP 8.0.0.